### PR TITLE
S3バケット名生成シェル：大文字を生成文字列に入れないように修正

### DIFF
--- a/scripts/generate-random-name.sh
+++ b/scripts/generate-random-name.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-r=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 20 | head -1)
+r=$(cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 20 | head -1)
 echo "swagger-${r}"


### PR DESCRIPTION
『実践サーバレスで実装するWebAPI』（boothでは『実践サーバレスで構築するWebAPI』）
16ページで
```
make generate-random-name
```
を実行して生成された文字列でS3バケットを作成しようと 
```
make create-swagger-bucket
```
したところ
```
An error occurred (InvalidBucketName) when calling the CreateBucket operation: The specified bucket is not valid.
```
というエラーで作成できず、調べたところ大文字は受け入れられないようなので修正しました。
よろしければマージしてください。
