### PR TITLE
GetMicropostが正しいリストを返せていないバグを修正

### DIFF
--- a/controllers/microposts_test.go
+++ b/controllers/microposts_test.go
@@ -239,14 +239,14 @@ func TestGetMicroposts(t *testing.T) {
 
 	actualMicroposts := body["microposts"].([]interface{})
 
-	expected1 := micropostMocks[0].(*models.Micropost)
+	expected1 := micropostMocks[1].(*models.Micropost)
 	actual1 := actualMicroposts[0].(map[string]interface{})
 	assert.Equal(t, float64(expected1.ID), actual1["id"])
 	assert.Equal(t, expected1.Content, actual1["content"])
 	assert.Equal(t, float64(expected1.UserID), actual1["user_id"])
 
 	expected2 := micropostMocks[0].(*models.Micropost)
-	actual2 := actualMicroposts[0].(map[string]interface{})
+	actual2 := actualMicroposts[1].(map[string]interface{})
 	assert.Equal(t, float64(expected2.ID), actual2["id"])
 	assert.Equal(t, expected2.Content, actual2["content"])
 	assert.Equal(t, float64(expected2.UserID), actual2["user_id"])

--- a/models/micropost.go
+++ b/models/micropost.go
@@ -123,8 +123,8 @@ func GetMicropostsByUserID(userID uint64) ([]*Micropost, error) {
 	}
 
 	var microposts = make([]*Micropost, len(micropostDynamo))
-	for i, m := range micropostDynamo {
-		microposts[i] = &m.Micropost
+	for i := range micropostDynamo {
+		microposts[i] = &micropostDynamo[i].Micropost
 	}
 
 	return microposts, nil


### PR DESCRIPTION
Goのfor rangeでのポインタでハマったこと
https://qiita.com/uchiko/items/1c611f0db618ce9dc0a9

上記の記事で解説している現象が起因で、起こっているバグです。